### PR TITLE
Fix CMake not found message on build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN dpkg --add-architecture i386
 # The second are deps that are needed but not in the minimal ubuntu 14.04 base image.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf2.13 bison bzip2 ccache curl flex gawk gcc g++ g++-multilib gcc-4.6 g++-4.6 g++-4.6-multilib git lib32ncurses5-dev lib32z1-dev zlib1g:amd64 zlib1g-dev:amd64 zlib1g:i386 zlib1g-dev:i386 libgl1-mesa-dev libx11-dev make zip libxml2-utils && \
-    apt-get install -y python python-dev openjdk-7-jdk wget libdbus-glib-1-dev libxt-dev unzip
+    apt-get install -y python python-dev openjdk-7-jdk wget libdbus-glib-1-dev libxt-dev unzip cmake
 
 # We need to use gcc-4.6 to build, set that as default.
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 1


### PR DESCRIPTION
When building, I got the following message:

        CMake not found, will not compile apitrace

Adding the `cmake` package to the list of packages to install results in the following message instead:

        CMake and NDK (/B2G/prebuilt/ndk/android-ndk-r7) found, will compile apitrace