### PR TITLE
Explicitly use Ubuntu 14.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:14.04
 MAINTAINER Simon Johansson <simon@simonjohansson.com>
 
 RUN dpkg --add-architecture i386


### PR DESCRIPTION
The README states that the base image is Ubuntu 14.04, the names of the installed packages are valid for Ubuntu 14.04, and, at the current time, Ubuntu 14.04 is the latest LTS release, so `FROM ubuntu` currently selects 14.04. However, if a new LTS were to come out, `ubuntu` would refer to that instead.

This patch explicitly states our dependency on 14.04. When a new LTS comes out, we can test whether the build script works on a the new version, and if it does, update the `FROM` line.